### PR TITLE
add support for carrier config overrides

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -9,10 +9,20 @@
     <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
     <uses-permission android:name="android.permission.WRITE_APN_SETTINGS" />
 
+    <permission
+        android:name="app.grapheneos.carrierconfig2.FORCE_UPDATE_CONFIG"
+        android:protectionLevel="signature|privileged" />
+
     <application
         android:label="CarrierConfig2"
         android:defaultToDeviceProtectedStorage="true"
         android:directBootAware="true">
+
+        <provider
+            android:name=".UpdateConfigProvider"
+            android:authorities="app.grapheneos.carrierconfig2.UpdateConfigProvider"
+            android:exported="true"
+            android:permission="app.grapheneos.carrierconfig2.FORCE_UPDATE_CONFIG" />
 
         <service
             android:name=".CarrierServiceImpl"

--- a/src/app/grapheneos/carrierconfig2/CarrierServiceImpl.java
+++ b/src/app/grapheneos/carrierconfig2/CarrierServiceImpl.java
@@ -32,7 +32,7 @@ public class CarrierServiceImpl extends CarrierService {
             carrierIdExt = new CarrierIdentifierExt(carrierId, Utils.getIccid(ctx, subId));
         }
 
-        return new CarrierConfigLoader(ctx, csd).load(carrierIdExt);
+        return new CarrierConfigLoader(ctx, csd).load(subId, carrierIdExt);
     }
 
     @Override

--- a/src/app/grapheneos/carrierconfig2/UpdateConfigProvider.java
+++ b/src/app/grapheneos/carrierconfig2/UpdateConfigProvider.java
@@ -1,0 +1,83 @@
+package app.grapheneos.carrierconfig2;
+
+import android.Manifest;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Binder;
+import android.os.Bundle;
+import android.telephony.CarrierConfigManager;
+import android.telephony.SubscriptionManager;
+
+import android.annotation.Nullable;
+
+import java.util.Arrays;
+
+public class UpdateConfigProvider extends ContentProvider {
+    private static final String TAG = "UpdCfgProvider";
+
+    public static final String METHOD_UPDATE_CONFIG = "updateConfig";
+    public static final String ARG_SUBID = "subId";
+
+    private static final String ALLOWED_PACKAGE = "com.android.settings";
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public Bundle call(@Nullable String method, @Nullable String arg, @Nullable Bundle extras) {
+        getContext().enforceCallingOrSelfPermission(
+                Manifest.permission.MODIFY_PHONE_STATE, "MODIFY_PHONE_STATE required");
+        final String[] pkgs = getContext().getPackageManager()
+                .getPackagesForUid(Binder.getCallingUid());
+        if (pkgs == null || !Arrays.asList(pkgs).contains(ALLOWED_PACKAGE)) {
+            throw new SecurityException("Only " + ALLOWED_PACKAGE + " may call this provider");
+        }
+
+        if (method == null) return null;
+        if (METHOD_UPDATE_CONFIG.equals(method)) {
+            if (extras == null) return null;
+            final int subId = extras.getInt(ARG_SUBID, SubscriptionManager.INVALID_SUBSCRIPTION_ID);
+            if (subId == SubscriptionManager.INVALID_SUBSCRIPTION_ID) {
+                return null;
+            }
+
+            final long token = Binder.clearCallingIdentity();
+            try {
+                // notifyConfigChangedForSubId done here in order for Telephony's CarrierConfigLoader
+                // to properly delete the cached configs from CarrierConfig2 and trigger a reload.
+                // The cache is keyed by carrier config app, and notifyConfigChangedForSubId uses
+                // the calling package as a key for the cached config to delete.
+                final var manager = getContext().getSystemService(CarrierConfigManager.class);
+                manager.notifyConfigChangedForSubId(subId);
+            } finally {
+                Binder.restoreCallingIdentity(token);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection,
+            String selection, String[] selectionArgs, String sortOrder) {
+        throw new IllegalStateException("unused");
+    }
+    @Override
+    public String getType(Uri uri) {
+        throw new IllegalStateException("unused");
+    }
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        throw new IllegalStateException("unused");  }
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        throw new IllegalStateException("unused");
+    }
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        throw new IllegalStateException("unused");
+    }
+}

--- a/src/app/grapheneos/carrierconfig2/loader/CarrierConfigLoader.java
+++ b/src/app/grapheneos/carrierconfig2/loader/CarrierConfigLoader.java
@@ -4,9 +4,13 @@ import android.annotation.Nullable;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.PersistableBundle;
+import android.os.RemoteException;
 import android.service.carrier.CarrierIdentifier;
 import android.telephony.CarrierConfigManager;
+import android.telephony.TelephonyFrameworkInitializer;
 import android.util.Log;
+
+import com.android.internal.telephony.ISub;
 
 import com.google.carrier.CarrierConfig;
 import com.google.carrier.CarrierSettings;
@@ -42,7 +46,7 @@ public class CarrierConfigLoader {
     }
 
     // carrierId is null when SIM is missing
-    public PersistableBundle load(@Nullable CarrierIdentifierExt carrierIdExt) {
+    public PersistableBundle load(int subId, @Nullable CarrierIdentifierExt carrierIdExt) {
         CSettings cSettings = null;
         if (carrierIdExt != null) {
             cSettings = CSettings.get(csd, carrierIdExt);
@@ -77,7 +81,29 @@ public class CarrierConfigLoader {
         } else {
             return null;
         }
+
+        final PersistableBundle overrides;
+        try {
+            overrides = getSubService().getExtOverrideConfigs(subId);
+        } catch (RemoteException e) {
+            Log.e(TAG, "overrides unavailable", e);
+            return bundle;
+        }
+
+        if (overrides != null && !overrides.isEmpty()) {
+            Log.d(TAG, "applying " + overrides.size() + " overrides");
+            bundle.putAll(overrides);
+        }
+
         return bundle;
+    }
+
+    private ISub getSubService() {
+        return ISub.Stub.asInterface(
+                TelephonyFrameworkInitializer
+                        .getTelephonyServiceManager()
+                        .getSubscriptionServiceRegisterer()
+                        .get());
     }
 
     private PersistableBundle cSettingsToBundle(CSettings cs) {

--- a/src/app/grapheneos/carrierconfig2/loader/CmpTest.java
+++ b/src/app/grapheneos/carrierconfig2/loader/CmpTest.java
@@ -93,7 +93,8 @@ public class CmpTest {
 
             CarrierIdentifierExt carrierIdExt = new CarrierIdentifierExt(carrierInfo.first, carrierInfo.second.getIccId());
 
-            PersistableBundle ourCarrierServiceResult = ccl.load(carrierIdExt);
+            PersistableBundle ourCarrierServiceResult = ccl.load(
+                    carrierInfo.second.getSubscriptionId(), carrierIdExt);
             compareCarrierConfigs(canonicalName, gcsCarrierConfigs, ourCarrierServiceResult);
 
             List<ContentValues> gcsApns = Arrays.asList(gcsConfigs.getParcelableArray(


### PR DESCRIPTION
Part of changeset 
- frameworks/base: https://github.com/GrapheneOS/platform_frameworks_base/pull/256
- frameworks/opt/telephony: https://github.com/GrapheneOS/platform_frameworks_opt_telephony/pull/11
- packages/providers/TelephonyProvider: https://github.com/GrapheneOS/platform_packages_providers_TelephonyProvider/pull/3
- packages/apps/CarrierConfig2: Here
- packages/app/Settings: https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/377

Exposed as a Service with AIDL for Settings app to connect to. Stored in new SimInfo's extended SIM state column (requires infrastructure)