### PR TITLE
Add VVM3 config override for Visible (Verizon MVNO)

### DIFF
--- a/src/app/grapheneos/carrierconfig2/loader/CarrierConfigLoader.java
+++ b/src/app/grapheneos/carrierconfig2/loader/CarrierConfigLoader.java
@@ -71,6 +71,7 @@ public class CarrierConfigLoader {
 
         if (cSettings != null) {
             bundle.putAll(cSettingsToBundle(cSettings));
+            VvmConfigOverrides.apply(cSettings.carrierId2.canonicalName, bundle);
             addVersionString(defaults, cSettings, bundle);
         } else if (defaults != null) {
             addVersionString(defaults, null, bundle);

--- a/src/app/grapheneos/carrierconfig2/loader/VvmConfigOverrides.java
+++ b/src/app/grapheneos/carrierconfig2/loader/VvmConfigOverrides.java
@@ -1,0 +1,48 @@
+package app.grapheneos.carrierconfig2.loader;
+
+import android.os.PersistableBundle;
+import android.telephony.CarrierConfigManager;
+
+/**
+ * Provides Visual Voicemail (VVM) carrier config overrides for carriers whose
+ * CarrierSettings protobuf files are missing VVM configuration.
+ *
+ * The CarrierSettings protobuf database extracted from stock Pixel images does not
+ * always include VVM config for every carrier. When KEY_VVM_TYPE_STRING is absent,
+ * the AOSP Dialer cannot activate visual voicemail. This class provides the missing
+ * VVM config values based on known carrier VVM infrastructure.
+ */
+class VvmConfigOverrides {
+    /**
+     * Apply VVM config overrides if the carrier's protobuf is missing VVM settings.
+     * Only injects values when KEY_VVM_TYPE_STRING is not already set.
+     */
+    static void apply(String canonicalName, PersistableBundle bundle) {
+        String existingVvmType = bundle.getString(CarrierConfigManager.KEY_VVM_TYPE_STRING);
+        if (existingVvmType != null && !existingVvmType.isEmpty()) {
+            return;
+        }
+
+        switch (canonicalName) {
+            case "visiblev_us":
+                // Visible (Verizon MVNO) uses Verizon's VVM3 infrastructure.
+                // Values sourced from AOSP Dialer vvm_config.xml for MCC/MNC 311480.
+                applyVerizonVvm3(bundle);
+                break;
+        }
+    }
+
+    /**
+     * Verizon VVM3 config, used by Verizon and its MVNOs (e.g. Visible).
+     * Source: AOSP platform/packages/apps/Dialer vvm_config.xml
+     */
+    private static void applyVerizonVvm3(PersistableBundle bundle) {
+        bundle.putString(CarrierConfigManager.KEY_VVM_TYPE_STRING, "vvm_type_vvm3");
+        bundle.putString(CarrierConfigManager.KEY_VVM_DESTINATION_NUMBER_STRING, "900080006200");
+        bundle.putInt(CarrierConfigManager.KEY_VVM_PORT_NUMBER_INT, 0);
+        bundle.putString(CarrierConfigManager.KEY_VVM_CLIENT_PREFIX_STRING, "//VZWVVM");
+        bundle.putBoolean(CarrierConfigManager.KEY_VVM_PREFETCH_BOOL, true);
+        bundle.putBoolean(CarrierConfigManager.KEY_VVM_CELLULAR_DATA_REQUIRED_BOOL, true);
+        bundle.putBoolean(CarrierConfigManager.KEY_VVM_LEGACY_MODE_ENABLED_BOOL, true);
+    }
+}


### PR DESCRIPTION
## Problem

Visual voicemail is broken on Visible wireless (MCC 311, MNC 480, MVNO GID `BAE2000000000000`). The `visiblev_us.pb` carrier settings protobuf has no VVM configuration — `vvm_type_string`, `vvm_destination_number_string`, and `vvm_port_number_int` are all missing.

Diagnostic evidence from device:
- `adb shell dumpsys carrier_config | grep vvm_type_string` → empty
- VVM status shows `data_channel_state=-9001` (IMAP data channel never connects)
- Stale VVM status row shows `source_type=vvm_type_vvm3` (confirming Verizon VVM3 infrastructure)

The AOSP Dialer's `vvm_config.xml` fallback (which historically provided VVM defaults for Verizon MCC/MNC ranges) was [removed in Android R](https://android.googlesource.com/platform/packages/apps/Dialer/+/7c1f4da2a686b8e5ee323ce08ae9624ea796e642), making CarrierConfig2 the only source of VVM configuration for the OS.

## Fix

Adds a `VvmConfigOverrides` class that injects VVM carrier config values when the protobuf database is missing them. For Visible, it provides the Verizon VVM3 config values sourced from the [AOSP Dialer's historical vvm_config.xml](https://android.googlesource.com/platform/packages/apps/Dialer/+/refs/heads/oreo-dev/java/com/android/voicemail/impl/res/xml/vvm_config.xml) for MCC/MNC 311480:

| Key | Value |
|-----|-------|
| `vvm_type_string` | `vvm_type_vvm3` |
| `vvm_destination_number_string` | `900080006200` |
| `vvm_port_number_int` | `0` |
| `vvm_client_prefix_string` | `//VZWVVM` |
| `vvm_prefetch_bool` | `true` |
| `vvm_cellular_data_required_bool` | `true` |
| `vvm_legacy_mode_enabled_bool` | `true` |

The override only applies when `KEY_VVM_TYPE_STRING` is not already set, so it will not conflict if Google adds VVM config to the protobuf in a future update.

## Design

The `VvmConfigOverrides` class uses a switch on the carrier's canonical name, making it easy to add VVM overrides for other carriers in the future. The check-then-apply pattern ensures existing protobuf VVM config always takes precedence.

## Verification

**Before:**
```
$ adb shell dumpsys carrier_config | grep vvm_type_string
vvm_type_string =
```

**After:**
```
$ adb shell dumpsys carrier_config | grep vvm_type_string
vvm_type_string = vvm_type_vvm3
```

Expected result: VVM status transitions from `data_channel_state=-9001` to `data_channel_state=0`, and voicemails sync with transcriptions.

## References

- Fixes GrapheneOS/os-issue-tracker#1629 (Visible VVM broken)
- Related: GrapheneOS/os-issue-tracker#1108 (VVM not activating)
- [AOSP Visual Voicemail documentation](https://source.android.com/docs/core/permissions/voicemail)
- [AOSP Dialer VVM config (pre-removal)](https://android.googlesource.com/platform/packages/apps/Dialer/+/refs/heads/oreo-dev/java/com/android/voicemail/impl/res/xml/vvm_config.xml)
- [CarrierConfigManager VVM keys](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/telephony/java/android/telephony/CarrierConfigManager.java)
- [VVM3 protocol implementation](https://android.googlesource.com/platform/packages/services/Telephony/+/b250ce8/src/com/android/phone/vvm/omtp/protocol/Vvm3Protocol.java)
- [GrapheneOS forum: VVM with Verizon MVNOs](https://discuss.grapheneos.org/d/17825-visual-voicemail-with-verzion-mnvos)