### PR TITLE
Fix duplicate `uneditedClause` appended to DELETE query in `Apns.java`

### DIFF
--- a/src/app/grapheneos/carrierconfig2/loader/Apns.java
+++ b/src/app/grapheneos/carrierconfig2/loader/Apns.java
@@ -151,7 +151,7 @@ public class Apns {
         Log.d(TAG, "uri: " + uri + "; where: " + where
                 + "; selArgs: " + Arrays.toString(selectionArgs));
 
-        int numDeletedRows = cr.delete(uri, where + uneditedClause, selectionArgs);
+        int numDeletedRows = cr.delete(uri, where, selectionArgs);
         Log.d(TAG, "numDeletedRows " + numDeletedRows);
     }
 


### PR DESCRIPTION
In `deleteUneditedApnsForCarrierId`, `uneditedClause` is already concatenated into `where` in both branches of the if/else, but is then appended a second time at the `ContentResolver.delete()` call site.

The resulting SQL contains a redundant `AND edited_status=0 AND edited_status=0`. While this is idempotent and causes no incorrect deletes today, it's misleading and could become a real bug if the clause or surrounding logic is ever changed.

**Fix:** Remove the redundant `+ uneditedClause` from the `cr.delete()` call.