### PR TITLE
install CarrierConfig2 in full and profile users

### DIFF
--- a/etc/sysconfig/app.grapheneos.carrierconfig2.xml
+++ b/etc/sysconfig/app.grapheneos.carrierconfig2.xml
@@ -1,5 +1,7 @@
 <config>
     <install-in-user-type package="app.grapheneos.carrierconfig2">
         <install-in user-type="SYSTEM" />
+        <install-in user-type="FULL" />
+        <install-in user-type="PROFILE" />
     </install-in-user-type>
- </config>
+</config>

--- a/src/app/grapheneos/carrierconfig2/loader/CarrierConfigLoader.java
+++ b/src/app/grapheneos/carrierconfig2/loader/CarrierConfigLoader.java
@@ -22,6 +22,7 @@ import app.grapheneos.carrierconfig2.Prefs;
 
 public class CarrierConfigLoader {
     public static final String TAG = CarrierConfigLoader.class.getSimpleName();
+    private static final Object APN_UPDATE_LOCK = new Object();
 
     private final Context context;
     private final CSettingsDir csd;
@@ -51,11 +52,13 @@ public class CarrierConfigLoader {
                 // OS doesn't request the APNs itself (except for ApnService.onRestoreApns()), carrier
                 // config app is expected to update APNs on its own.
 
-                if (isCurrentApnCSettingsVersion(cSettings)) {
-                    Log.d(TAG, "CSettings version hasn't changed, skipping APN update");
-                } else {
-                    Apns.update(context, cSettings);
-                    storeApnCSettingsVersion(cSettings);
+                synchronized (APN_UPDATE_LOCK) {
+                    if (isCurrentApnCSettingsVersion(cSettings)) {
+                        Log.d(TAG, "CSettings version hasn't changed, skipping APN update");
+                    } else {
+                        Apns.update(context, cSettings);
+                        storeApnCSettingsVersion(cSettings);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8307

CarrierConfigLoader binds the carrier config service for the current user. Install CarrierConfig2 in full and profile users so the service can be resolved outside user 0. This appears to be the intended upstream design of the platform carrier config app.[^1][^2]

CarrierConfig2 keeps process-wide caches through its static default CSettingsDir, so a user 0 singleton service would be able to share those caches across users. However, Telephony accesses CarrierConfig2 as a different app, so using the service as a singleton would require CarrierConfig2 to hold the INTERACT_ACROSS_USERS_FULL permission.

Telephony keeps the loaded carrier config cache in the phone process and persists carrier config XML to DE storage under a key derived from the carrier config app package name, ICCID and specific carrier ID. Cache hits avoid binding CarrierConfig2 at all. CarrierConfig2's carrier config service is only queried when Telephony cannot restore a valid cached config, such as for a new SIM, changed specific carrier ID, package version mismatch (not independently possible for CarrierConfig2 while it is installed in system_ext; OS updates are covered by the build fingerprint check), build fingerprint change or explicit cache clear.

Assuming a user doesn't regularly add new SIMs or carrier IDs during ordinary operation, this usually means the service is not bound at all on cache-hit boots and is very likely to be bound at most once per boot for a given active SIM/cache entry when the cache has to be refreshed. As of this CP2A tree, Settings also gates the mobile network entry point on admin users and disables the subscription gear for non-admin users, so ordinary secondary users cannot reach SIM settings through the normal Settings UI.

On a cache miss, Telephony binds the service, requests config, saves the returned bundle and unbinds from the service in the result callback. Telephony doesn't use the service as a long-lived binding; CarrierConfig2 can therefore be killed after unbind if the system needs more memory. This would not lose Telephony's cache.

Given this access pattern, making CarrierConfig2's carrier config service a singleton and granting INTERACT_ACROSS_USERS_FULL does not appear worth the additional privileged multiuser service surface for this fix.

Also, keep APN update state changes serialized, because theoretically multiple service entrypoints can request config loading in the same app process.

Test: manual, switch to secondary user and trigger config change by removing and inserting physical SIM, or do `ICarrierConfigLoader#updateConfigForPhoneId(int phoneId, String simState)` by running `adb shell service call carrier_config 6 i32 0 s16 LOADED`. There should be no more logs from CarrierConfigLoader saying "Failed to get package version for: app.grapheneos.carrierconfig2" or "binding to default app: app.grapheneos.carrierconfig2 fails", and sending MMS should be full sized

[^1]: https://github.com/GrapheneOS/platform_packages_services_Telephony/commit/ddb0862187cfc541ffd8e0efbac4782cab1e284
[^2]: https://github.com/GrapheneOS/platform_build/commit/5552bd8fc3b89fb7d040686cf899a12953eb345a